### PR TITLE
feat: fetching of a secured Algolia key [BB-8083]

### DIFF
--- a/src/components/my-career/CategoryCard.jsx
+++ b/src/components/my-career/CategoryCard.jsx
@@ -13,6 +13,7 @@ import algoliasearch from 'algoliasearch/lite';
 import { AppContext } from '@edx/frontend-platform/react';
 import LevelBars from './LevelBars';
 import SkillsRecommendationCourses from './SkillsRecommendationCourses';
+import { useAlgoliaSearch } from "../../utils/hooks";
 
 const CategoryCard = ({ topCategory }) => {
   const { skillsSubcategories } = topCategory;
@@ -26,16 +27,7 @@ const CategoryCard = ({ topCategory }) => {
 
   const config = getConfig();
   const { enterpriseConfig } = useContext(AppContext);
-  const courseIndex = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      return client.initIndex(config.ALGOLIA_INDEX_NAME);
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY],
-  );
+  const [courseIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME);
 
   const filterRenderableSkills = (skills) => {
     const renderableSkills = [];

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -36,6 +36,7 @@ import SearchPathwayCard from '../pathway/SearchPathwayCard';
 import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 import PathwayModal from '../pathway/PathwayModal';
 import { useEnterpriseCuration } from './content-highlights/data';
+import { useAlgoliaSearch } from "../../utils/hooks";
 
 const Search = () => {
   const { pathwayUUID } = useParams();
@@ -78,17 +79,7 @@ const Search = () => {
   }, [openLearnerPathwayModal, pathwayUUID]);
 
   const config = getConfig();
-  const courseIndex = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      const cIndex = client.initIndex(config.ALGOLIA_INDEX_NAME);
-      return cIndex;
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY],
-  );
+  const [courseIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME);
 
   const PAGE_TITLE = `${HEADER_TITLE} - ${enterpriseConfig.name}`;
   const shouldDisplayBalanceAlert = hasNoEnterpriseOffersBalance || hasLowEnterpriseOffersBalance;

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -38,6 +38,7 @@ import {
 import { SkillsContext } from './SkillsContextProvider';
 import { SET_KEY_VALUE } from './data/constants';
 import { checkValidGoalAndJobSelected } from '../utils/skills-quiz';
+import { useAlgoliaSearch } from "../../utils/hooks";
 import TopSkillsOverview from './TopSkillsOverview';
 import SkillsQuizHeader from './SkillsQuizHeader';
 
@@ -48,18 +49,9 @@ import { fetchCourseEnrollments } from './data/service';
 const SkillsQuizStepper = () => {
   const config = getConfig();
   const { userId } = getAuthenticatedUser();
-  const [searchClient, courseIndex, jobIndex] = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      const cIndex = client.initIndex(config.ALGOLIA_INDEX_NAME);
-      const jIndex = client.initIndex(config.ALGOLIA_INDEX_NAME_JOBS);
-      return [client, cIndex, jIndex];
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_INDEX_NAME_JOBS, config.ALGOLIA_SEARCH_API_KEY],
-  );
+  const [courseIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME);
+  const [jobSearchClient, jobIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME_JOBS);
+
   const [currentStep, setCurrentStep] = useState(STEP1);
   const [isStudentChecked, setIsStudentChecked] = useState(false);
   const handleIsStudentCheckedChange = e => setIsStudentChecked(e.target.checked);
@@ -198,7 +190,7 @@ const SkillsQuizStepper = () => {
                   <div>
                     <InstantSearch
                       indexName={config.ALGOLIA_INDEX_NAME_JOBS}
-                      searchClient={searchClient}
+                      searchClient={jobSearchClient}
                     >
                       <Configure
                         facetingAfterDistinct

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,6 +34,8 @@ initialize({
         LICENSE_MANAGER_URL: process.env.LICENSE_MANAGER_URL || null,
         ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID || null,
         ALGOLIA_SEARCH_API_KEY: process.env.ALGOLIA_SEARCH_API_KEY || null,
+        ALGOLIA_SECURED_KEY_ENDPOINT: process.env.ALGOLIA_SECURED_KEY_ENDPOINT ||
+          `${process.env.LMS_BASE_URL}/enterprise/api/v1/enterprise-customer/algolia_key/`,
         ALGOLIA_INDEX_NAME: process.env.ALGOLIA_INDEX_NAME || null,
         ALGOLIA_INDEX_NAME_JOBS: process.env.ALGOLIA_INDEX_NAME_JOBS || null,
         INTEGRATION_WARNING_DISMISSED_COOKIE_NAME: process.env.INTEGRATION_WARNING_DISMISSED_COOKIE_NAME || null,

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,6 +1,7 @@
 import Cookies from 'universal-cookie';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
+import { logError } from '@edx/frontend-platform/logging';
 import dayjs from './dayjs';
 
 export const isCourseEnded = endDate => dayjs(endDate) < dayjs();
@@ -63,6 +64,22 @@ export const loginRefresh = async () => {
       cookies.remove(config.ACCESS_TOKEN_COOKIE_NAME);
     }
     return Promise.resolve();
+  }
+};
+
+export const fetchAlgoliaSecuredApiKey = async () => {
+  const config = getConfig();
+  const httpClient = getAuthenticatedHttpClient();
+
+  try {
+    const response = await httpClient.get(config.ALGOLIA_SECURED_KEY_ENDPOINT);
+    if (response && response.data) {
+      return response.data.key;
+    }
+    throw new Error('Response does not contain data');
+  } catch (error) {
+    logError(error);
+    return null;
   }
 };
 

--- a/src/utils/hooks.jsx
+++ b/src/utils/hooks.jsx
@@ -24,22 +24,25 @@ export const useRenderContactHelpText = (enterpriseConfig) => {
   return renderContactHelpText;
 };
 
+let cachedApiKey = null;
+
 export const useAlgoliaSearchApiKey = (config) => {
   // If the search API key is not provided in the config,
   // fetch it from `ALGOLIA_SECURED_KEY_ENDPOINT`.
 
-  const [searchApiKey, setSearchApiKey] = useState(config.ALGOLIA_SEARCH_API_KEY);
+  const [searchApiKey, setSearchApiKey] = useState(cachedApiKey || config.ALGOLIA_SEARCH_API_KEY);
 
   useEffect(() => {
     const fetchApiKey = async () => {
       const key = await fetchAlgoliaSecuredApiKey();
+      cachedApiKey = key;
       setSearchApiKey(key);
     };
 
-    if (!config.ALGOLIA_SEARCH_API_KEY) {
+    if (!searchApiKey) {
       fetchApiKey();
     }
-  }, [config.ALGOLIA_SEARCH_API_KEY]);
+  }, [searchApiKey]);
 
   return searchApiKey;
 }

--- a/src/utils/hooks.jsx
+++ b/src/utils/hooks.jsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import algoliasearch from 'algoliasearch';
+
+import { fetchAlgoliaSecuredApiKey } from './common';
 
 export const useRenderContactHelpText = (enterpriseConfig) => {
   const renderContactHelpText = useCallback(
@@ -22,17 +24,38 @@ export const useRenderContactHelpText = (enterpriseConfig) => {
   return renderContactHelpText;
 };
 
+export const useAlgoliaSearchApiKey = (config) => {
+  // If the search API key is not provided in the config,
+  // fetch it from `ALGOLIA_SECURED_KEY_ENDPOINT`.
+
+  const [searchApiKey, setSearchApiKey] = useState(config.ALGOLIA_SEARCH_API_KEY);
+
+  useEffect(() => {
+    const fetchApiKey = async () => {
+      const key = await fetchAlgoliaSecuredApiKey();
+      setSearchApiKey(key);
+    };
+
+    if (!config.ALGOLIA_SEARCH_API_KEY) {
+      fetchApiKey();
+    }
+  }, [config.ALGOLIA_SEARCH_API_KEY]);
+
+  return searchApiKey;
+}
+
 export const useAlgoliaSearch = (config, indexName) => {
+  const algoliaSearchApiKey = useAlgoliaSearchApiKey(config);
   const [searchClient, searchIndex] = useMemo(
     () => {
       const client = algoliasearch(
         config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
+        algoliaSearchApiKey,
       );
       const index = client.initIndex(indexName || config.ALGOLIA_INDEX_NAME);
       return [client, index];
     },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY, indexName],
+    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, algoliaSearchApiKey, indexName],
   );
   return [searchClient, searchIndex];
 };


### PR DESCRIPTION
## Description

Adds a fallback mechanism, so when the `ALGOLIA_SEARCH_API_KEY` environment variable is not set, the key is fetched from the endpoint defined by the `ALGOLIA_SECURED_KEY_ENDPOINT` environment variable. It expects this endpoint to return a JSON like:
```json
{
  "key": "<ALGOLIA_SEARCH_API_KEY>"
}
```
This is intended, but not limited to, to be used with https://github.com/open-craft/edx-enterprise/pull/11.

## Testing steps

We're going to test this PR, https://github.com/open-craft/edx-enterprise/pull/11 and https://github.com/open-craft/edx-platform/pull/602 at once by creating three courses and three enterprise customers, uploading them to Algolia through `enterprise-catalog` and checking that learners are able to browse catalogs of their enterprises with the help of this MFE, but unable to access courses of enterprises they don't belong to.

#### Prerequisites

You'll need an Algolia account. Create an application and `enterprise-catalog` index. Write down the application id, admin API key, and search API key somewhere.

#### Installing Palm devstack
```bash
mkdir palm && cd palm
export DEVSTACK_WORKSPACE=$(pwd)
git clone -b open-release/palm.master git@github.com:openedx/devstack.git && cd devstack
virtualenv -p python3 .fenv
source .fenv/bin/activate
export OPENEDX_RELEASE=palm.master
make requirements
make dev.clone
docker pull edxops/devpi && docker tag edxops/devpi edxops/devpi:palm.master && docker pull edxops/ecommerce && docker tag edxops/ecommerce edxops/ecommerce:palm.master && docker pull edxops/credentials && docker tag edxops/credentials edxops/credentials:palm.master && docker pull edxops/notes && docker tag edxops/notes edxops/notes:palm.master
cd ..
git clone -b open-release/palm.master git@github.com:openedx/configuration.git && cd configuration
docker build -f docker/build/forum/Dockerfile . -t edxops/forum:palm.master
cd ../edx-platform
git remote add oc git@github.com:open-craft/edx-platform.git
git fetch oc 0x29a/bb8083/per-user-algolia-key
git checkout 0x29a/bb8083/per-user-algolia-key
DOCKER_BUILDKIT=1 docker build . --build-arg SERVICE_VARIANT=lms --build-arg SERVICE_PORT=8000 --target development -t openedx/lms-dev:palm.master
cd ../devstack
sed -i s/"make requirements"/"pip install --upgrade pip==23.1 \&\& make requirements"/g provision-credentials.sh
make dev.provision
make dev.up.large-and-slow
```
After that:
1. `cd ../edx-platform`
2. Add `ENTERPRISE_ALGOLIA_SEARCH_API_KEY = '<YOUR_ALGOLIA_SEARCH_(NOT ADMIN)_API_KEY>'` to the end of `lms/envs/devstack.py`.
#### Installing edx-enterprise fork
```bash
sudo chown $USER:$USER ../src
cd ../src
git clone -b 0x29a/bb8083/per-user-algolia-key git@github.com:open-craft/edx-enterprise.git
cd ../devstack
make lms-shell
cd /edx/src/edx-enterprise/
pip uninstall edx-enterprise
pip install -e .
exit
make lms-shell
python manage.py lms migrate
exit
make studio-shell
cd /edx/src/edx-enterprise/
pip uninstall edx-enterprise
pip install -e .
exit
make lms-restart
make studio-restart
```
#### Installing enterprise-catalog
```bash
cd ..
git clone -b open-release/palm.master git@github.com:openedx/enterprise-catalog.git && cd enterprise-catalog
sed -i s/devstack_default/devstack-palmmaster_default/g docker-compose.yml
sed -i s/edx.devstack/edx.devstack-palm.master/g provision-catalog.sh enterprise_catalog/settings/devstack.py enterprise_catalog/apps/catalog/fixtures/contentmetadata.json
```
After that:
1. Open `enterprise_catalog/apps/catalog/constants.py` and add `'source'` to the `CONTENT_PRODUCT_SOURCE_ALLOW_LIST` set.
2. Add the following to the end of `enterprise_catalog/settings/devstack.py`:
    ```python
    ALGOLIA = {
        'INDEX_NAME': 'enterprise-catalog',
        'APPLICATION_ID': '<YOUR_ALGOLIA_APPLICATION_ID>',
        'API_KEY': '<YOUR_ADMIN_ALGOLIA_API_KEY>',
    }
    ```
3. Run `make dev.provision`.
#### Installing frontend-app-learner-portal-enterprise
```bash
cd ..
git clone -b 0x29a/bb8083/per-user-algolia-key git@github.com:open-craft/frontend-app-learner-portal-enterprise.git && cd frontend-app-learner-portal-enterprise
export ALGOLIA_APP_ID=<YOUR_ALGOLIA_APPLICATION_ID>
export ALGOLIA_INDEX_NAME=enterprise-catalog
nvm use
npm install
npm start
```
Leave this terminal open, do all the remaining steps in a separate one.
#### Creating test entities
1. Create three courses here: http://localhost:18010/home/. Use `ABC`, `XYZ`, and `PSY` for all fields, like here:
   ![image](https://github.com/open-craft/frontend-app-learner-portal-enterprise/assets/18251194/89b10b44-be98-43b7-8558-fd3d08e8a445)
2. Add a section with a dropdown unit to each course, publish each.
3. Set `Course Start Date` and `Enrollment Start Date` for each course [here](http://localhost:18010/settings/details/course-v1:PSY+PSY+PSY) to `01/01/2019`.
4. Add all three courses [here](http://localhost:18130/courses/new/), like this:
   ![image](https://github.com/open-craft/frontend-app-learner-portal-enterprise/assets/18251194/80aba072-26e9-4e36-99c0-7cc65d622db4)
5. Add `verified` and `audit` course modes for each course here: http://localhost:18000/admin/course_modes/coursemode/
6. Create a source with a `Source` name here: http://localhost:18381/admin/course_metadata/source/add/
7. Go [here](http://localhost:18000/admin/enterprise/enterprisecatalogquery/) and create three queries with the following content filters for each course:
    ```json
    {
        "content_type":[
            "course",
            "courserun"
        ],
        "aggregation_key":[
            "course:ABC+ABC",
            "courserun:ABC+ABC"
        ],
        "partner":"edx",
        "availability":[
            "Current",
            "Starting Soon",
            "Upcoming"
        ],
        "status":"published"
    }
    ```
    Change `ABC` to `XYZ` and `PSY` for each query.
8. Go [here](http://localhost:18000/admin/enterprise/enterprisecustomer/) and create three enterprise customers: `XXX`, `YYY`, `ZZZ`. Change their slugs respectively. Check `Enable learner portal` for each. 
9. Go [here](http://localhost:18000/admin/enterprise/enterprisecustomercatalog/add/) and create three catalogs for each customer selecting different course queries we created earlier.  `XXX` should be assigned to the query selecting `ABC` course, `YYY` -> `XYZ` and `ZZZ` -> `PSY.`

#### Indexing
Go to the `<DEVSTACK_WORKSPACE>` and replace `DEFAULT_PRODUCT_SOURCE_SLUG = ''` with `DEFAULT_PRODUCT_SOURCE_SLUG = 'source'` in `course_discovery/settings/base.py`.

Then, go to the `<DEVSTACK_WORKSPACE>/devstack` directory run the following to pull the data from LMS to Course Discovery:
```bash
export OPENEDX_RELEASE=palm.master
make discovery-shell
./manage.py refresh_course_metadata
```

Then:
1. Go [here](http://localhost:18381/admin/course_metadata/organization/) and set a name for each organization.
2. Go [here](http://localhost:18381/admin/course_metadata/courserun/) and change every course run to be "Published"
3. Run the following in the discovery shell to fill in the product source for each course and update the ES index:
```bash
./manage.py populate_default_product_source
./manage.py update_index --disable-change-limit
exit
```

Now we need to copy course queries and other enterprise-related data from LMS to `enterprise-catalog`. Run the following:
```bash
make lms-shell
./manage.py lms migrate_enterprise_catalogs --api_user enterprise_catalog_worker
```
This will fail, but it'll create a `enterprise_catalog_worker` user [here](http://localhost:18160/admin/core/user/). Go [here](http://localhost:18160/admin/catalog/enterprisecatalogroleassignment/) and assign `enterprise_catalog_admin` role to `enterprise_catalog_worker@example.com`, don't forget to check `Applies to all contexts`.
Now, run this again:
```bash
./manage.py lms migrate_enterprise_catalogs --api_user enterprise_catalog_worker
```
After that you should see three of your course queries [here](http://localhost:18160/admin/catalog/catalogquery/).

Now, go to the `<DEVSTACK_WORKSPACE>/enterprise-catalog` and run the following to fetch content metadata (courses and course runs) from Course Discovery:

```bash
make app-shell
./manage.py update_content_metadata --force
```

After that you should see `Course` and `Course Run` objects for each of your courses [here](http://localhost:18160/admin/catalog/contentmetadata/). If you don't, then something went wrong. Also, `Json metadata` for each course should contain a non-empty `advertised_course_run_uuid`.

Now you can upload all courses to Algolia:
```bash
./manage.py reindex_algolia
```

If everything go fine, you should see three courses in your `enterprise-catalog` Algolia index.

#### Enrolling users

1. Register a new user: `abc@example.com`.
2. Go the `XXX` enterprise customer and click `Manager Learners` ([example of the admin panel URL](http://localhost:18000/admin/enterprise/enterprisecustomer/a00728ba-b5ee-45a1-8a6d-73ea3870ccec/manage_learners)).
3. Now, enroll `abc@example.com` user to the `course-v1:ABC+ABC+ABC` course. Specify `Audit` track and `test` reason for manual enrollment.
4. ^ This will fail. But a new `enterprise_worker` user will appear [here](http://localhost:18160/admin/core/user/). Assign the `enterprise_catalog_admin` role to the `enterprise_worker@example.com` user [here](http://localhost:18160/admin/catalog/enterprisecatalogroleassignment/) (don't forget to check `Applies to all contexts`) and try point 3 again.
5. Repeat points 2 and 3, but for `YYY` enterprise customer and `course-v1:XYZ+XYZ+XYZ` course, so we have a single learner present in two different enterprises.

#### Testing frontend-app-learner-portal-enterprise

1. Sign out as `abc@example.com`.
2. Go to `http://localhost:8734`.
3. You should be redirected to the LMS.
4. Upon signing in again as `abc@example.com`, you should be offered to choose an organization. Choose `XXX`.
5. You should be redirected to the MFE. You shoud see the `ABC` course [here](http://localhost:8734/xxx/search?showAll=1).
6. Now, if you visit [this URL](http://localhost:18000/enterprise/select/active/?success_url=http%3A%2F%2Flocalhost%3A8734%2F) again and select `YYY`, you should see the `XYZ` course.

Now, open the browser dev tools and locate a query like this:
```
https://ql3i9veweo-dsn.algolia.net/1/indexes/*/queries?x-algolia-agent=Algolia for JavaScript (4.6.0); Browser; JS Helper (3.12.0); react (17.0.2); react-instantsearch (6.38.1)
```
1. Click the right mouse button on it and `Edit and Resend` (that's for Firefox).
2. Paste the following JSON to the `Body` field and click `Send`:
    ```json
    {
      "requests": [
        {
          "indexName": "enterprise-catalog",
          "params": "facetingAfterDistinct=true&facets=%5B%5D&highlightPostTag=%3C%2Fais-highlight-0000000000%3E&highlightPreTag=%3Cais-highlight-0000000000%3E&tagFilters="
        }
      ]
    }
    ```
    Normally, this request would fetch all courses from the index. But the MFE is using our secured Algolia key now.
3. Observe what this query returned. There should be only 2 hits, for the `ABC` and `XYZ` courses, omitting the `PSY` course.

## Upstream PR

https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/887