### PR TITLE
feat(palm): add footer SCSS import and use tilde for module resolution

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,10 +1,11 @@
-@import "@edx/brand/paragon/fonts";
-@import "@edx/brand/paragon/variables";
-@import "@edx/paragon/scss/core/core";
+@import "~@edx/brand/paragon/fonts";
+@import "~@edx/brand/paragon/variables";
+@import "~@edx/paragon/scss/core/core";
 // frontend-enterprise-* imports must come before the paragon overrides for correct styling
 @import "~@edx/frontend-enterprise-catalog-search";
-@import "@edx/brand/paragon/overrides";
+@import "~@edx/brand/paragon/overrides";
 
+@import "~@edx/frontend-component-footer/dist/footer";
 
 @import "./components/layout/styles/Layout";
 @import "./components/course/styles/CourseHeader";


### PR DESCRIPTION
The webpack's tilde syntax resolves SCSS imports from node_modules to make the development easier.

This backports https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/1015 to Palm.

_Private-ref: [BB-8620](https://tasks.opencraft.com/browse/BB-8620)_
