### PR TITLE
fix: use full path in the enrollment failure urls

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -299,9 +299,9 @@ export const useCourseEnrollmentUrl = ({
     () => ({
       next: `${config.LMS_BASE_URL}/courses/${courseRunKey}/course`,
       // Redirect back to the same page with a failure query param
-      failure_url: `${global.location.origin}${location.pathname}?${baseQueryParams.toString()}`,
+      failure_url: `${global.location.origin}${global.location.pathname}?${baseQueryParams.toString()}`,
     }),
-    [config.LMS_BASE_URL, courseRunKey, baseQueryParams, location.pathname],
+    [config.LMS_BASE_URL, courseRunKey, baseQueryParams],
   );
 
   const enrollmentUrl = useMemo(

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -793,7 +793,7 @@ export const createEnrollFailureUrl = ({ courseRunKey, location }) => {
   baseQueryParams.set(ENROLLMENT_FAILED_QUERY_PARAM, true);
   baseQueryParams.set(ENROLLMENT_COURSE_RUN_KEY_QUERY_PARAM, courseRunKey);
 
-  return `${global.location.origin}${location.pathname}?${baseQueryParams.toString()}`;
+  return `${global.location.origin}${global.location.pathname}?${baseQueryParams.toString()}`;
 };
 
 export const createEnrollWithLicenseUrl = ({


### PR DESCRIPTION
The enrollment failure URLs were using the React Router's location.pathname, which omits the basename when the MFE is deployed in a sub-directory. This commit instead uses the global.location.pathname (browser location api) to make sure that the full path including the sub-directory is used.

### Screenshot showing the different between the 2 location objects

![pathname](https://github.com/open-craft/frontend-app-learner-portal-enterprise/assets/383862/2aa2d8cc-6d41-4841-b48d-978266964ab2)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
