### PR TITLE
[BB-9491] fix 404 pages on course details for other catalogs

### DIFF
--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -68,6 +68,7 @@ export default class CourseService {
         availableCourseRunKeys = res.data.filtered_content_keys;
         courseDetails.courseRunKeys = courseDetails.courseRunKeys.filter(k => availableCourseRunKeys.includes(k));
         courseDetails.courseRuns = courseDetails.courseRuns.filter(run => availableCourseRunKeys.includes(run.key));
+        this.activeCourseRun = courseDetails.courseRuns[0];
       }
     }
 

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -129,6 +129,11 @@ export const numberWithPrecision = (number, precision = 2) => number.toFixed(pre
 // See https://openedx.atlassian.net/wiki/spaces/WS/pages/1045200922/Enroll+button+and+Course+Run+Selector+Logic
 // for more detailed documentation on course run selection and the enroll button.
 export function getActiveCourseRun(course) {
+  // This is a hacky way to set the active course run. However, for the current use case
+  // the enterprise is bound to get a single course run in after filtering in CourseService
+  if (course.courseRuns.length == 1) {
+    return course.courseRuns[0];
+  }
   return course.courseRuns.find(courseRun => courseRun.uuid === course.advertisedCourseRunUuid);
 }
 


### PR DESCRIPTION
The previous PR #7 filtered the courses to the single course run allowed in the enteprise-catalog. However, the solution had the bug of not setting the correct `activeCourseRun`. So, only the enterprise learners with the "advertisedCourseRun" could see the details.

This PR fixes that bug by setting the `activeCourseRun` of the `CourseService` and patching the `getActiveCourseRun` utility function to return only the available course run, when only 1 is present.

### Before

![image](https://github.com/user-attachments/assets/68417d9f-f04e-4200-9436-e1c08e706f45)

### After

![image](https://github.com/user-attachments/assets/a74dcfc6-806e-4fde-8312-fea68371ca63)


## Testing Instructions

Similar to the instructions from #7 for setup. Then switch to the second enterprise and load the course details page in Enterprise Learner Portal. 

1. **In the BB-8825-custom-ui branch** - The page would show a 404 page.
2. Switch to the PR branch - It should show the "Enroll" button (with or without warning dependending on the subsidy or license status).

