### PR TITLE
fix: handle license activation failures gracefully

### DIFF
--- a/src/components/app/LoginRefresh.jsx
+++ b/src/components/app/LoginRefresh.jsx
@@ -2,8 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   fetchAuthenticatedUser,
-  getAuthenticatedUser,
-  setAuthenticatedUser,
+  hydrateAuthenticatedUser,
 } from '@edx/frontend-platform/auth';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Container } from '@edx/paragon';
@@ -24,15 +23,19 @@ const LoginRefresh = ({ children }) => {
     const refreshJWT = async () => {
       await loginRefresh();
       // Refreshing the JWT only replaces the cookie; the in-memory `authenticatedUser`
-      // (snapshotted into AppContext at app init) still carries the pre-refresh roles.
-      // Re-decode the refreshed cookie, then publish the change through the
-      // interface-level `setAuthenticatedUser`, which emits AUTHENTICATED_USER_CHANGED
-      // so AppProvider updates AppContext. `fetchAuthenticatedUser()` alone does NOT
-      // emit that event — it updates the auth service's internal state only, leaving
-      // every AppContext consumer (e.g. the enterprise_learner role check that gates
-      // license auto-apply) reading stale roles for the rest of the session.
+      // (snapshotted into AppContext at app init) still carries the pre-refresh roles,
+      // so consumers like the enterprise_learner check that gates license auto-apply
+      // would read stale roles for the rest of the session.
+      //
+      // `fetchAuthenticatedUser()` re-decodes the refreshed cookie, but (a) it does not
+      // emit AUTHENTICATED_USER_CHANGED, so AppProvider would never propagate the new
+      // user into AppContext, and (b) it replaces the user object outright, dropping
+      // account fields (e.g. `profileImage`) that `hydrateAuthenticatedUser()` may have
+      // already merged — EnterprisePage blocks on `profileImage`, so dropping it hangs
+      // the app on its loading screen. Re-hydrating merges those fields back onto the
+      // freshly-decoded user AND emits AUTHENTICATED_USER_CHANGED.
       await fetchAuthenticatedUser();
-      setAuthenticatedUser(getAuthenticatedUser());
+      await hydrateAuthenticatedUser();
       setIsRefreshingJWT(false);
     };
     if (isRefreshingJWT) {

--- a/src/components/app/LoginRefresh.jsx
+++ b/src/components/app/LoginRefresh.jsx
@@ -1,5 +1,10 @@
 import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import {
+  fetchAuthenticatedUser,
+  getAuthenticatedUser,
+  setAuthenticatedUser,
+} from '@edx/frontend-platform/auth';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Container } from '@edx/paragon';
 
@@ -18,6 +23,16 @@ const LoginRefresh = ({ children }) => {
   useEffect(() => {
     const refreshJWT = async () => {
       await loginRefresh();
+      // Refreshing the JWT only replaces the cookie; the in-memory `authenticatedUser`
+      // (snapshotted into AppContext at app init) still carries the pre-refresh roles.
+      // Re-decode the refreshed cookie, then publish the change through the
+      // interface-level `setAuthenticatedUser`, which emits AUTHENTICATED_USER_CHANGED
+      // so AppProvider updates AppContext. `fetchAuthenticatedUser()` alone does NOT
+      // emit that event — it updates the auth service's internal state only, leaving
+      // every AppContext consumer (e.g. the enterprise_learner role check that gates
+      // license auto-apply) reading stale roles for the rest of the session.
+      await fetchAuthenticatedUser();
+      setAuthenticatedUser(getAuthenticatedUser());
       setIsRefreshingJWT(false);
     };
     if (isRefreshingJWT) {

--- a/src/components/course/SubsidyRequestButton.jsx
+++ b/src/components/course/SubsidyRequestButton.jsx
@@ -71,18 +71,24 @@ const SubsidyRequestButton = () => {
   /**
    * Show subsidy request button if:
    *  - subsidy requests is enabled
-   *    - user has a subsidy request for course
+   *  - user is not already enrolled in the course
+   *  - user has no applicable subsidy for the course
+   *  AND
+   *    - user has a subsidy request for the course
    *      OR
    *    - course is in catalog
-   *    - user not already enrolled in crouse
-   *    - user has no subsidy for course
+   *
+   * An applicable subsidy (e.g. an auto-applied license that reaches the browser after a
+   * request was already submitted) always wins over a pending request. Without the explicit
+   * `!userSubsidyApplicableToCourse` guard, a stale `userHasSubsidyRequest` would keep the
+   * button latched on "Awaiting approval" even once the learner has a usable subsidy and the
+   * normal "Enroll" CTA is available.
    */
   const hasSubsidyRequestsEnabled = subsidyRequestConfiguration?.subsidyRequestsEnabled;
-  const showSubsidyRequestButton = hasSubsidyRequestsEnabled && (
-    userHasSubsidyRequest || (
-      subsidyRequestCatalogsApplicableToCourse.size > 0 && !isUserEnrolled && !userSubsidyApplicableToCourse
-    )
-  );
+  const showSubsidyRequestButton = hasSubsidyRequestsEnabled
+    && !isUserEnrolled
+    && !userSubsidyApplicableToCourse
+    && (userHasSubsidyRequest || subsidyRequestCatalogsApplicableToCourse.size > 0);
 
   if (!showSubsidyRequestButton) {
     return null;

--- a/src/components/enterprise-user-subsidy/data/hooks/hooks.js
+++ b/src/components/enterprise-user-subsidy/data/hooks/hooks.js
@@ -129,6 +129,17 @@ export function useSubscriptionLicense({
       // when the enterprise customer has an SSO/LMS provider configured.
       if (!result && enterpriseIdentityProvider && isEnterpriseLearner && hasCustomerAgreementData) {
         result = await requestAutoAppliedUserLicense(customerAgreementConfig.uuid);
+
+        // The auto-apply request can fail on the client (e.g. a network timeout, or a
+        // duplicate request when a license was already auto-applied) while the license is
+        // still created/activated server-side. `requestAutoAppliedUserLicense` swallows that
+        // error and returns null, which would leave the learner with no license in the UI and
+        // incorrectly route them into Browse & Request ("Request enrollment" / "Awaiting
+        // approval"). Reconcile by re-fetching the user's licenses so a license that was
+        // applied server-side still reaches the browser.
+        if (!result) {
+          result = await fetchExistingUserLicense(enterpriseId);
+        }
       }
 
       return result;


### PR DESCRIPTION
## Description

Fixes learners ending up in Browse & Request ("Request enrollment" / "Awaiting approval") even though they are entitled to — or already hold — an auto-applied subscription license (BB-10977).

### Root cause: stale JWT roles after login refresh

A new SSO learner's first JWT cookie is minted **before** their `enterprise_learner` role assignment exists, so it carries `roles: []`. `LoginRefresh` detects this and refreshes the cookie via `/login_refresh` — but only the cookie: the in-memory `authenticatedUser` snapshotted into `AppContext` at app init still has no roles. The `enterprise_learner` check gating license auto-apply in `useSubscriptionLicense` then fails **silently** (no request, no log), and the learner is routed into Browse & Request. On their next full page load the refreshed cookie decodes with roles and auto-apply succeeds — which is why admins reviewing enrollment requests kept finding learners who already had valid licenses.

**Fix (`LoginRefresh`):** after `loginRefresh()`, re-decode the refreshed cookie with `fetchAuthenticatedUser()` and then `hydrateAuthenticatedUser()`. The hydrate call is essential: `fetchAuthenticatedUser()` alone does not emit `AUTHENTICATED_USER_CHANGED` (AppContext would never update) and it replaces the user object, dropping account fields like `profileImage` that `EnterprisePage` blocks on — which hangs the app on its loading screen (the failure mode noted in the old `UserSubsidy` workaround comment).

### Root cause 2 (secondary): client-side auto-apply failures are swallowed

`requestAutoAppliedUserLicense` swallows errors and returns `null`, so an auto-apply POST that fails client-side (timeout, dropped connection) while succeeding server-side also strands the learner in Browse & Request.

**Fixes:**
- `useSubscriptionLicense`: if the auto-apply request fails, reconcile by re-fetching the user's licenses so a license applied server-side still reaches the browser.
- `SubsidyRequestButton`: never render the request button when the user is enrolled or already has an applicable subsidy — a usable subsidy always wins over a stale pending request ("Awaiting approval" no longer sticks after the license lands).

### Testing

Verified end-to-end in a local Tutor enterprise environment:

- **Stale-roles scenario** (role assignment deleted before first login, restored after — mirroring production timing): pre-fix, a learner landing directly on a course page saw "Request enrollment" with **no auto-apply attempt at all**, matching production logs. Post-fix, the same scenario produced `POST /login_refresh` → auto-apply `POST … 200` → license activated → "Enroll" rendered, in a single page load.
- **Network-failure scenario** (proxy forwarding the auto-apply POST to license-manager but dropping the response): pre-fix, the learner got "Request enrollment" despite an activated license and could file a request; post-fix, the license re-fetch reconciled and "Enroll" rendered — no request created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)